### PR TITLE
Add image.imagePullPolicy to values.yaml

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -19,6 +19,7 @@ image:
   tag: ""
   # imagePullSecrets:
   #   - name: secretname
+  # imagePullPolicy: IfNotPresent
 logVolume: co-config-volume
 logConfigMap: strimzi-cluster-operator
 logConfiguration: ""


### PR DESCRIPTION
### Type of change
- Documentation

### Description
The operator `Deployment` template contains the provision to customize the `imagePullPolicy`, but that's not mentioned in the `values.yaml`.
This PR makes it clearer.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

